### PR TITLE
Update escape-room.md

### DIFF
--- a/_drafts/escape-room.md
+++ b/_drafts/escape-room.md
@@ -1,9 +1,12 @@
 ---
 layout: post
-title: Die JavaLand 2021 wird ein riesiges Escape-Game
+title: Escape-Game auf der JavaLand und online?
 ---
 
+Wie ihr wisst, denken wir derzeit intensiv über Ideen für hybride Veranstaltungen nach, die vielleicht auch für die JavaLand 2021 ungesetzt werden könnten. Heute möchten wir euch die Idee eines riesigen escape-Spiels präsentieren, bei der Inka und Markus Brand (Autoren der bekannten Exit-Spielreihe im Kosmos-Verlag) mitgestalten. Stellt euch das vor:
 
-Die JavaLand 2021 wird phantastisch! Passend dazu wird die JavaLand wieder im stilechten Ambiente stattfinden. Zusätzlich konnten wir Inka und Markus Brand, Autoren der bekannten Exit-Spielreihe im Kosmos-Verlag, gewinnen mit uns ein riesiges Escape-Spiel zu gestalten. Das Spiel wird sich über zwei Tage erstrecken und mit dem Konferenzprogramm kombiniert sein. Es wird sowohl Dinge im JavaLand vor Ort zu entdecken als auch Rätsel zum remote knobeln geben. Und für den besonderen Kick wird es einige richtig knifflige Rätsel geben, die nur gelöst werden können, wenn wirklich viele vor Ort und remote Hand in Hand daran knobeln. Das wird am Besten mit der Übertragung einer unserer Live-Cams gehen, die ausgewählte Teilnehmerinnen und Teilnehmer vor Ort bekommen können.
+Das Spiel erstreckt sich über zwei Tage und ist mit dem Konferenzprogramm kombiniert. Es gibt sowohl Dinge vor Ort zu entdecken, als auch Rätsel zum Remote-Knobeln. Und für den besonderen Kick gibt es einige richtig knifflige Rätsel, die nur gelöst werden können, wenn wirklich viele vor Ort und remote Hand in Hand daran knobeln. Das geht am besten mit der Übertragung über Live-Cams, die ausgewählte Teilnehmerinnen und Teilnehmer vor Ort bekommen können.
 
-Einige Teile der Story sind schon geschrieben, aber wir können immer noch die wildesten und unglaublichsten Ideen für Rätsel, Wunder und Knobeleien einbauen, die Euch einfallen. Also her damit! Lasst uns wissen, wie kreativ Ihr seid und schreibt uns an escape-2021@javaland.eu.
+ Einige Teile der Story sind schon geschrieben, aber wir können immer noch die wildesten und unglaublichsten Ideen für Rätsel, Wunder und Knobeleien einbauen, die Euch einfallen. Also her damit! Lasst uns wissen, wie kreativ Ihr seid und schreibt uns an escape-2021@ijug.eu.
+
+Vielleicht lässt sich die Idee oder Teile davon auf einer phantastischen JavaLand 2021 im stilechten Ambiente umsetzen! 


### PR DESCRIPTION
ich bin mit der arbeit in gitup nicht unbedingt vertraut - bisher habe ich nur lesend reingeschaut. ich hoffe, was ich gerade mache, ist im sinne des erfinders. ich wurde heute darüber in kenntnis gesetzt, dass es aufgrund der gestrigen besprechung die empfehlung gibt, diese inhalte auf vision.ijug.eu zu bringen, wo sie unredigiert veröffentlicht werden, weil ihr euch commitet , euch nicht konkret auf die javaland zu beziehen und dort keine ankündigungen macht, die nicht offiziell im vorfeld abgestimmt wurden. 

der text hier liest sich ziemlich genau so, als ob es in der form auf der javaland 2021 umgesetzt wird. darüber hinaus soll der blog auf einer ijug-subdomain sein. es wäre also auch logisch, dass die domain der mail-adresse auch ijug ist. 

da diese empfehlung offensichtlich nicht schriftlich festgehalten wurde, würde ich vorschlagen, dass wir es nachholen. vielleicht liegt einfach nur ein missverständnis vor.